### PR TITLE
Change model and provider display format for OpenSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ For multi-package releases, use package names as subsections:
 
 ## [Unreleased]
 
+### Changed
+
+- Changed model sync to send model name instead of model ID for better readability in OpenSync dashboards
+- Changed provider sync to replace hyphens with spaces (e.g., `anthropic-bedrock` → `anthropic bedrock`)
+
 ## [0.1.0]
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,8 +130,8 @@ export default function piOpensyncPlugin(pi: ExtensionAPI) {
     state = {
       sessionId: ctx.sessionManager.getSessionId(),
       projectPath: ctx.cwd,
-      model: ctx.model?.id,
-      provider: ctx.model?.provider,
+      model: ctx.model?.name,
+      provider: ctx.model?.provider?.replace(/-/g, " "),
       ...stats,
       startedAt: Date.now(),
     };
@@ -154,8 +154,8 @@ export default function piOpensyncPlugin(pi: ExtensionAPI) {
       sessionId: ctx.sessionManager.getSessionId(),
       parentSessionId,
       projectPath: ctx.cwd,
-      model: ctx.model?.id,
-      provider: ctx.model?.provider,
+      model: ctx.model?.name,
+      provider: ctx.model?.provider?.replace(/-/g, " "),
       ...stats,
       startedAt: Date.now(),
     };
@@ -185,8 +185,8 @@ export default function piOpensyncPlugin(pi: ExtensionAPI) {
    */
   pi.on("model_select", async (event, _ctx) => {
     if (!state) return;
-    state.model = event.model.id;
-    state.provider = event.model.provider;
+    state.model = event.model.name;
+    state.provider = event.model.provider.replace(/-/g, " ");
   });
 
   /**


### PR DESCRIPTION
- Send model name instead of model ID for better readability
- Replace hyphens with spaces in provider names (e.g., 'anthropic-bedrock' -> 'anthropic bedrock')